### PR TITLE
Add parallel_degree function to nx-parallel

### DIFF
--- a/_nx_parallel/degree.py
+++ b/_nx_parallel/degree.py
@@ -1,0 +1,10 @@
+from joblib import Parallel, delayed
+import networkx as nx
+
+def parallel_degree(G, n_jobs=2):
+    """Calculate node degrees in parallel."""
+    def calc_degree(node):
+        return (node, G.degree(node))
+    
+    result = Parallel(n_jobs=n_jobs)(delayed(calc_degree)(node) for node in G.nodes())
+    return dict(result)


### PR DESCRIPTION
This PR adds a `parallel_degree` function to nx-parallel, which calculates node degrees in parallel using Joblib. This is a simple contribution to help speed up degree calculations for large graphs. I am preparing for GSoC and would appreciate feedback! @Schefflera-Arboricola @dschult