### PR TITLE
Add parallel_degree function to nx-parallel

### DIFF
--- a/_nx_parallel/__init__.py
+++ b/_nx_parallel/__init__.py
@@ -155,3 +155,5 @@ def get_info():
             },
         },
     }
+
+from .degree import parallel_degree


### PR DESCRIPTION
This PR adds a `parallel_degree` function to nx-parallel, which calculates node degrees in parallel using Joblib. This is a simple contribution to help speed up degree calculations for large graphs. I am preparing for GSoC and would appreciate feedback! @Schefflera-Arboricola @dschult